### PR TITLE
:sparkles: feat: Add cfp link to navbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "next": "14.1.0",
         "react": "^18",
         "react-dom": "^18",
+        "react-feather": "^2.0.10",
         "remark": "^15.0.1",
         "remark-html": "^16.0.1"
       },
@@ -6039,7 +6040,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6439,7 +6439,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6449,8 +6448,7 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/property-information": {
       "version": "6.4.1",
@@ -6523,6 +6521,17 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-feather": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/react-feather/-/react-feather-2.0.10.tgz",
+      "integrity": "sha512-BLhukwJ+Z92Nmdcs+EMw6dy1Z/VLiJTzEQACDUEnWMClhYnFykJCGWQx+NmwP/qQHGX/5CzQ+TGi8ofg2+HzVQ==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.6"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next": "14.1.0",
     "react": "^18",
     "react-dom": "^18",
+    "react-feather": "^2.0.10",
     "remark": "^15.0.1",
     "remark-html": "^16.0.1"
   },

--- a/src/app/components/Navbar/Navbar.css
+++ b/src/app/components/Navbar/Navbar.css
@@ -9,20 +9,22 @@ nav > ul {
     padding-bottom: 0.5rem;
 }
 
+nav > ul > li > a {
+    align-items: center;
+    border-bottom: 3px solid transparent;
+    color: var(--color-yellow-nantesjs);
+    display: flex;
+    font-family: var(--font-title);
+    font-size: 18px;
+    padding: 0.5rem;
+    text-decoration: none;
+}
 nav > ul > li:not(.cfp-link) {
     margin-right: 20px;
 }
 
 nav > ul > li:not(.cfp-link) > a {
-    border-bottom: 3px solid;
-    border-color: transparent;
-    color: var(--color-yellow-nantesjs);
-    font-family: var(--font-title);
-    font-size: 18px;
-    line-height: 2em;
-    padding-bottom: 0.5rem;
-    text-decoration: none;
-    transition: border-color ease 500ms;
+    transition: border-bottom-color ease 500ms;
 }
 
 nav ul > li:not(.cfp-link) > a.active {
@@ -35,24 +37,23 @@ nav > ul > li:not(.cfp-link) > a:hover {
     transition: border-color ease 500ms;
 }
 
-nav > ul > li.cfp-link {
-    border: 3px solid var(--color-yellow-nantesjs);
-}
+/* Specific : the CFP link */
 
 nav > ul > li.cfp-link > a {
     background-color: var(--color-yellow-nantesjs);
+    /*border: 3px solid var(--color-yellow-nantesjs);*/
     color: var(--color-dark-grey);
-    font-family: var(--font-title);
-    font-size: 18px;
-    line-height: 2em;
-    padding: 0.6rem 0.5rem;
-    text-decoration: none;
     transition: all ease 500ms;
 }
 
 nav > ul > li.cfp-link > a:hover {
     background-color: transparent;
+    border-color: var(--color-yellow-nantesjs);
     color: var(--color-yellow-nantesjs);
     transition: all ease 500ms;
+}
+
+nav > ul > li.cfp-link > a > svg {
+    margin-left: 0.5rem;
 }
 

--- a/src/app/components/Navbar/Navbar.jsx
+++ b/src/app/components/Navbar/Navbar.jsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { ExternalLink } from 'react-feather'
 import { NavLink } from '../NavLink'
 import './Navbar.css'
 
@@ -14,7 +15,12 @@ export function Navbar () {
                 <li><NavLink slug='contributeurs'>Contributeurs</NavLink></li>
                 <li><NavLink slug='code-de-conduite'>Code de conduite</NavLink></li>
                 <li><NavLink slug='a-propos'>À propos</NavLink></li>
-                <li className="cfp-link"><Link href={proposalLink}>Proposer un sujet</Link></li>
+                <li className="cfp-link">
+                    <Link href={proposalLink} target="_blank">
+                        Proposer un sujet
+                        <ExternalLink width={20} />
+                    </Link>
+                </li>
             </ul>
         </nav>
     )


### PR DESCRIPTION
Fix #8 

### :book: Summary
**As a** User
**I want to** have the CFP link
**So that** I can propose a talk
 
### :clipboard: Acceptance Criteria

_Test 1_
**Given** User is on a page
**When** he clicks on Submit link
**Then** he goes to the CFP site in a new tab or window

_Test 2_
**Given** User is on a page
**When** He reads the "Submit" link
**Then** He knows this is an external link
 
### :paintbrush: Design
<img width="1728" alt="Capture d’écran 2024-02-02 à 14 41 15" src="https://github.com/mcampourcy/nantesjs-website-nextjs/assets/11388201/c588157d-0ef9-475f-8131-be1377c5d20f">
